### PR TITLE
Add a checker for asserting that quantifiers are left operands.

### DIFF
--- a/checker/checker.go
+++ b/checker/checker.go
@@ -140,6 +140,8 @@ func (c *FileChecker) visitExpr(expr ast.Expr, report *Report) {
 	switch expr := expr.(type) {
 	case *ast.Ident:
 		c.visitIdent(expr, report)
+	case *ast.BinaryExpr:
+		c.visitBinaryExpr(expr, report)
 	case *ast.FuncLit:
 		c.visitFuncLit(expr, report)
 	case *ast.StructType:
@@ -153,6 +155,12 @@ func (c *FileChecker) visitExpr(expr ast.Expr, report *Report) {
 
 func (c *FileChecker) visitIdent(ident *ast.Ident, report *Report) {
 	c.emit(ident, "", report)
+}
+
+func (c *FileChecker) visitBinaryExpr(expr *ast.BinaryExpr, report *Report) {
+	c.emit(expr, "", report)
+	c.visitExpr(expr.X, report)
+	c.visitExpr(expr.Y, report)
 }
 
 func (c *FileChecker) visitFuncLit(lit *ast.FuncLit, report *Report) {

--- a/checker/left_quantifiers.go
+++ b/checker/left_quantifiers.go
@@ -1,0 +1,76 @@
+package checker
+
+import (
+	"fmt"
+	"go/ast"
+	"go/token"
+)
+
+func init() {
+	must(Register("left_quantifiers", NewLeftQuantifiersChecker))
+}
+
+// LeftQuantifiersChecker checks that when a basic literal appears in a binary
+// expression it is the left operand.
+type LeftQuantifiersChecker struct {
+	errorPositions map[token.Pos]struct{}
+}
+
+// NewLeftQuantifiersChecker constructs a BasicLiteralLeftOperandChecker.
+func NewLeftQuantifiersChecker(configData interface{}) NodeChecker {
+	return &LeftQuantifiersChecker{}
+}
+
+// Register implements the NodeChecker interface.
+func (c *LeftQuantifiersChecker) Register(fc *FileChecker) {
+	fc.On(&ast.BinaryExpr{}, c)
+}
+
+// Check implements the NodeChecker interface.
+func (c *LeftQuantifiersChecker) Check(
+	node ast.Node,
+	content string,
+	report *Report) {
+
+	expr := node.(*ast.BinaryExpr)
+	if _, ok := c.errorPositions[expr.OpPos]; ok {
+		return
+	}
+
+	positions := map[token.Pos]struct{}{}
+	if !assertLeftQuantifiers(node, positions) {
+		c.errorPositions = positions
+		report.Errors = append(report.Errors,
+			fmt.Errorf("the left operand should be a basic literal"))
+	}
+
+}
+
+func assertLeftQuantifiers(node ast.Node, pos map[token.Pos]struct{}) bool {
+	switch expr := node.(type) {
+	case *ast.BinaryExpr:
+		pos[expr.OpPos] = struct{}{}
+		if assertBasicLit(expr.X, pos) {
+			return assertLeftQuantifiers(expr.Y, pos)
+		}
+		return !assertBasicLit(expr.Y, pos)
+	case *ast.ParenExpr:
+		return assertLeftQuantifiers(expr.X, pos)
+	default:
+		return true
+	}
+}
+
+func assertBasicLit(node ast.Node, pos map[token.Pos]struct{}) bool {
+	switch expr := node.(type) {
+	case *ast.BinaryExpr:
+		pos[expr.OpPos] = struct{}{}
+		return assertBasicLit(expr.X, pos) && assertBasicLit(expr.Y, pos)
+	case *ast.ParenExpr:
+		return assertBasicLit(expr.X, pos)
+	case *ast.BasicLit:
+		return true
+	default:
+		return false
+	}
+}

--- a/checker/left_quantifiers_test.go
+++ b/checker/left_quantifiers_test.go
@@ -1,0 +1,97 @@
+package checker_test
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/s2gatev/lingo/checker"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLeftQuantifiers(t *testing.T) {
+	type test struct {
+		description string
+		expression  string
+		expected    Report
+	}
+
+	input := `
+		package main
+
+		import "time"
+
+		func main() {
+			%s
+		}
+	`
+
+	tests := []test{
+		{
+			description: "basic literal is not on the left",
+			expression:  `_ = time.Second * 5`,
+			expected: Report{
+				Errors: []error{
+					fmt.Errorf("the left operand should be a basic literal"),
+				},
+			},
+		},
+		{
+			description: "multiple binary operations, basic literal at the end",
+			expression:  `_ = 2 + time.Second * 3`,
+			expected: Report{
+				Errors: []error{
+					fmt.Errorf("the left operand should be a basic literal"),
+				},
+			},
+		},
+		{
+			description: "mixed expressions",
+			expression:  `_ = time.Duration(1) * 2 * 5 * time.Second`,
+			expected: Report{
+				Errors: []error{
+					fmt.Errorf("the left operand should be a basic literal"),
+				},
+			},
+		},
+		{
+			description: "multiple binary operations, not a basic literal at the end",
+			expression:  `_ = 60 - 10 + 60 * time.Second`,
+			expected: Report{
+				Errors: nil,
+			},
+		},
+		{
+			description: "binary expression with parentheses",
+			expression:  `_ = (60 - 10) * 60 * time.Second`,
+			expected: Report{
+				Errors: nil,
+			},
+		},
+		{
+			description: "more than one non-basic expression on the right",
+			expression:  `_ = 2 + 22 * time.Duration(1) * time.Second`,
+			expected: Report{
+				Errors: nil,
+			},
+		},
+		{
+			description: "no basic literal in binary expression",
+			expression:  `_ = time.Duration(1) * time.Second`,
+			expected: Report{
+				Errors: nil,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			checker := NewFileChecker()
+			checker.Register(NewLeftQuantifiersChecker(nil))
+
+			file := ParseFileContent(fmt.Sprintf(input, test.expression))
+			var report Report
+			checker.Check(file, "", &report)
+			assert.Equal(t, test.expected, report)
+		})
+	}
+}

--- a/lingo.yml
+++ b/lingo.yml
@@ -26,3 +26,4 @@ checkers:
   line_length:
     max_length: 90
     tab_width: 4
+  left_quantifiers:


### PR DESCRIPTION
This rule ensures that when using basic literals as quantifiers, they are the left operands of the expression.

```go
_ = 2 * time.Hour              // this is OK
_ = 60 * 60 * time.Second      // this is OK
_ = (5 + 5) * 60 * time.Second // this is OK
_ = time.Minute * 5            // this is not OK
```